### PR TITLE
enhancements: reload app when lib is changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ It's a monorepo; with an Angular test application, after unchecking run
 
     git submodules update # this will get the spectre CSS framework for demo app
     yarn install --frozen-lockfile # install dependencies
-    yarn ng build social-sign-in # build module in /dist
     yarn start # launch the example application
 
 [yarn]: https://yarnpkg.com/

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,10 +19,10 @@
     ],
     "paths": {
       "@zsoltm/ngx-social-sign-in": [
-        "dist/social-sign-in"
+        "projects/social-sign-in/src/public_api"
       ],
       "@zsoltm/ngx-social-sign-in/*": [
-        "dist/social-sign-in/*"
+        "projects/social-sign-in/src/*"
       ]
     }
   }


### PR DESCRIPTION
the initial `yarn ng build social-sign-in` step can be removed by changing the path pointing to the library entry point.

This will give 2 benefits while working on the library.
 - one step less when starting working on the project
 - no need to rebuild the lib every lib you want to test something ( or no need to start a `yarn ng build social-sign-in --watch` process separately )

btw. `yarn ng build social-sign-in` is not working since it's not defined in the `angular.json`, it should have been `yarn ng build ngx-social-sign-in` as it's defined here: https://github.com/zsoltm/ngx-social-sign-in/blob/master/angular.json#L98

