### PR TITLE
fix: fix typo in demo app at google sign-in button

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,7 +9,7 @@
         [disabled]="signInStatus.facebook"><img src="assets/icons/facebook.svg" class="m-1" />Sign-in in with Facebook</button>
     <button class="btn btn-social"
         (click)="signInGoogle()"
-        [disabled]="signInStatus.google"><img src="assets/icons/google.svg" class="m-1" />Sing-in with Google</button>
+        [disabled]="signInStatus.google"><img src="assets/icons/google.svg" class="m-1" />Sign-in with Google</button>
     </div>
 
   <h2>Global Login Status</h2>


### PR DESCRIPTION
there was a typo at the google sign in button.

**before:**

`Sing-in`

**after:**

`Sign-in`