### PR TITLE
enhancement: remove git submodule manual step

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ Requirements:
 
 It's a monorepo; with an Angular test application, after unchecking run
 
-    git submodules update # this will get the spectre CSS framework for demo app
     yarn install --frozen-lockfile # install dependencies
     yarn ng build social-sign-in # build module in /dist
     yarn start # launch the example application

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "preinstall": "git submodule update --init",
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",


### PR DESCRIPTION
by adding the `git submodules update` command to preinstall, we can skip one more manual step when starting the local development.

btw. there is a typo: should be `git submodule update` instead of plural `submodules`.

the `--init` flag is required at the first step after you've just cloned the repo, so that's why the command ended up with: `git submodule update --init`